### PR TITLE
Simplify Consul server SSH key path output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ build-hello-client:
 # SSH into the self-hosted Consul server instance.
 .PHONY: ssh-consul-server
 ssh-consul-server:
-	ssh -i $$(terraform -chdir=environments/sh/sh-dc output -raw ssh_private_key_path) ubuntu@$$(terraform -chdir=environments/sh/sh-dc output -raw server_public_ip)
+	ssh -i shared/ssh/sh-dc-server-key.pem ubuntu@$$(terraform -chdir=environments/sh/sh-dc output -raw server_public_ip)

--- a/modules/sh/consul-server/main.tf
+++ b/modules/sh/consul-server/main.tf
@@ -36,10 +36,14 @@ resource "aws_key_pair" "server" {
   public_key = tls_private_key.ssh_key.public_key_openssh
 }
 
+locals {
+  ssh_private_key_path = abspath("${path.root}/../../../shared/ssh/${var.datacenter}-server-key.pem")
+}
+
 # Create directory for SSH keys
 resource "null_resource" "create_ssh_dir" {
   provisioner "local-exec" {
-    command = "mkdir -p ${path.module}/../../../shared/ssh"
+    command = "mkdir -p ${dirname(local.ssh_private_key_path)}"
   }
 }
 
@@ -47,8 +51,8 @@ resource "null_resource" "create_ssh_dir" {
 resource "local_file" "ssh_key_pem" {
   depends_on      = [null_resource.create_ssh_dir]
   content         = tls_private_key.ssh_key.private_key_pem
-  filename        = "${path.module}/../../../shared/ssh/${var.datacenter}-server-key.pem"
-  file_permission = "0600"
+  filename        = local.ssh_private_key_path
+  file_permission = "0400"
 }
 
 resource "aws_vpc" "main" {

--- a/modules/sh/consul-server/outputs.tf
+++ b/modules/sh/consul-server/outputs.tf
@@ -11,5 +11,5 @@ output "public_ip" {
 }
 
 output "ssh_private_key_path" {
-  value = local_file.ssh_key_pem.filename
+  value = local.ssh_private_key_path
 }


### PR DESCRIPTION
## Summary
- simplify Consul server SSH key handling by using a fixed path outside module directory
- update ssh-consul-server make target to reference new key location directly

## Testing
- `terraform fmt modules/sh/consul-server/main.tf modules/sh/consul-server/outputs.tf`


------
https://chatgpt.com/codex/tasks/task_e_68a4b1888454832295e33ae90dc587e8